### PR TITLE
add python3 support to pyreferrer

### DIFF
--- a/pyreferrer/__init__.py
+++ b/pyreferrer/__init__.py
@@ -1,1 +1,2 @@
-from referrer import *
+from __future__ import absolute_import
+from .referrer import *

--- a/pyreferrer/referrer.py
+++ b/pyreferrer/referrer.py
@@ -2,7 +2,13 @@ from __future__ import unicode_literals
 from .ruleset import Ruleset
 import json
 import tldextract
-from urlparse import urlparse, parse_qs
+
+try:
+  #Python2
+  from urlparse import urlparse, parse_qs
+except ImportError:
+  #Python3
+  from urllib.parse import urlparse, parse_qs
 
 class Referrer:
 

--- a/pyreferrer/referrer_test.py
+++ b/pyreferrer/referrer_test.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-
-from referrer import *
+from __future__ import absolute_import
+from .referrer import *
 from nose.tools import assert_equals
 
 def test_parse_splits_the_url_into_its_components():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='pyreferrer',
-      version='0.3.1',
+      version='0.3.2',
       description='A referrer parser for Python.',
       url='http://github.com/Shopify/pyreferrer',
       author='Steven Normore',


### PR DESCRIPTION
This PR adds support for Python3. I tested both Python2 and Python3 locally, and :ok_hand: 

For review, @pmangg and @snormore 
