### PR TITLE
pin tldexract for now and bump pyreferrer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='pyreferrer',
-      version='0.3.10.2',
+      version='0.3.10.3',
       description='A referrer parser for Python.',
       url='http://github.com/Shopify/pyreferrer',
       author='Steven Normore',
@@ -9,6 +9,6 @@ setup(name='pyreferrer',
       license='MIT',
       packages=['pyreferrer'],
       package_data={'pyreferrer': ['data/*', ]},
-      install_requires=['tldextract'],
+      install_requires=['tldextract==1.7.1'],
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
This pins tldextract (for now) so this library will continue to work. I'll open an issue to move us to 2.0. 

cc @daria-sukhareva 