### PR TITLE
Add Travis CI and trove classifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /venv/
 *.pyc
+pyreferrer.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+   - "2.7"
+   - "3.3"
+   - "3.4"
+   - "3.5"
+install:
+  - pip install -e '.[test]'
+script:
+  - nosetests
+notifications:
+  email: false

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,16 @@ setup(name='pyreferrer',
       packages=['pyreferrer'],
       package_data={'pyreferrer': ['data/*', ]},
       install_requires=['tldextract==2.0.1'],
+      extras_require={
+          'test': ['nose'],
+      },
+      classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+      ],
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
This adds a basic Travis CI config to test for Python 2.7, 3.3, 3.4, and 3.5 compatibility.

This also addes trove classifiers to ensure that [`caniusepython3`](https://pypi.python.org/pypi/caniusepython3) and [sites that rely on it](http://py3readiness.org/) can recognize that this library supports Python 3.

@snormore @CamDavidsonPilon 