### PR TITLE
WIP Additions to Pyreferrer April 2019

### DIFF
--- a/pyreferrer/data/referrers.json
+++ b/pyreferrer/data/referrers.json
@@ -1220,7 +1220,11 @@
                 "webcache.googleusercontent.com",
                 "encrypted.google.com",
                 "googlesyndicatedsearch.com",
-                "www.googleadservices.com"
+                "googlesyndication.com",
+                "doubleclick.net",
+                "googleadservices.com",
+                "googlesyndication.com",
+                ""
             ],
             "parameters": [
                 "q",
@@ -2763,6 +2767,15 @@
                 "Keywords"
             ]
         },
+        "MSN": {
+            "domains": [
+                "msn.com",
+                "msn.net"
+            ],
+            "parameters": [
+                "q"
+            ]
+        },
         "Monstercrawler": {
             "domains": [
                 "www.monstercrawler.com"
@@ -3497,6 +3510,32 @@
                 "q"
             ]
         },
+        "Yelp": {
+            "domains": [
+                "yelp.com",
+                "yelp.ca",
+                "yelp.co.uk",
+                "yelp.com.au",
+                "yelp.de",
+                "yelp.es",
+                "yelp.fr",
+                "yelp.ca",
+                "yelp.co.uk",
+                "yelp.co.nz",
+                "yelp.ie",
+                "yelp.com.hk",
+                "yelp.dk",
+                "yelp.it",
+                "yelp.com.sg",
+                "yelp.com.ph",
+                "yelp.com.br",
+                "yelp.com.ar",
+                "yelp.my"
+            ],
+            "parameters": [
+                "q"
+            ]
+        },
         "Yippy": {
             "domains": [
                 "search.yippy.com"
@@ -3903,7 +3942,27 @@
         },
         "Pinterest": {
             "domains": [
-                "pinterest.com"
+                "pinterest.com",
+                "pinterest.ca",
+                "pinterest.co.uk",
+                "pinterest.de",
+                "pinterest.fr",
+                "pinterest.es",
+                "pinterest.com.au",
+                "pinterest.it",
+                "pinterest.ru",
+                "pinterest.com.mx",
+                "pinterest.nz",
+                "pinterest.ph",
+                "pinterest.co.kr",
+                "pinterest.jp",
+                "pinterest.ie",
+                "pinterest.pt",
+                "pinterest.dk",
+                "pinterest.se",
+                "pinterest.cl",
+                "pinterest.ch",
+                "pinterest.ie"
             ]
         },
         "Plaxo": {
@@ -3929,6 +3988,12 @@
         "Renren": {
             "domains": [
                 "renren.com"
+            ]
+        },
+        "Share A Sale": {
+            "domains": [
+                "shareasale.com",
+                "shareasale-analytics.com"
             ]
         },
         "Skyrock": {
@@ -4068,6 +4133,16 @@
         }
     },
     "unknown": {
+        "Criteo": {
+            "domains": [
+                "criteo.com"
+            ]
+        },
+        "GMA Deals": {
+            "domains": [
+                "gmadeals.com"
+            ]
+        },
         "Google": {
             "domains": [
                 "support.google.com",
@@ -4079,6 +4154,54 @@
                 "groups.google.com",
                 "groups.google.co.uk",
                 "news.google.co.uk"
+            ]
+        },
+        "Laybuy": {
+            "domains": [
+                "laybuy.com"
+            ],
+            "parameters": [
+                "q"
+            ]
+        },
+        "Libertystmedia": {
+            "domains": [
+                "libertystmedia.com"
+            ]
+        },
+        "Linkin.bio": {
+            "domains": [
+                "linkin.bio"
+            ]
+        },
+        "Linktr.ee": {
+            "domains": [
+                "linktr.ee"
+            ]
+        },
+        "Outbrain": {
+            "domains": [
+                "outbrain.com"
+            ]
+        },
+        "Porn Hub": {
+            "domains": [
+                "pornhub.com"
+            ]
+        },
+        "smartURL": {
+            "domains": [
+                "smarturl.it"
+            ]
+        },
+        "Taboola": {
+            "domains": [
+                "taboola.com"
+            ]
+        },
+        "View Your Deal": {
+            "domains": [
+                "viewyourdeal.com"
             ]
         },
         "Yahoo!": {

--- a/pyreferrer/data/referrers.json
+++ b/pyreferrer/data/referrers.json
@@ -1222,8 +1222,7 @@
                 "googlesyndicatedsearch.com",
                 "googlesyndication.com",
                 "doubleclick.net",
-                "googleadservices.com",
-                "googlesyndication.com"
+                "googleadservices.com"
             ],
             "parameters": [
                 "q",
@@ -4173,9 +4172,6 @@
         "Laybuy": {
             "domains": [
                 "laybuy.com"
-            ],
-            "parameters": [
-                "q"
             ]
         },
         "Libertystmedia": {

--- a/pyreferrer/data/referrers.json
+++ b/pyreferrer/data/referrers.json
@@ -1223,8 +1223,7 @@
                 "googlesyndication.com",
                 "doubleclick.net",
                 "googleadservices.com",
-                "googlesyndication.com",
-                ""
+                "googlesyndication.com"
             ],
             "parameters": [
                 "q",
@@ -4036,6 +4035,11 @@
                 "taringa.net"
             ]
         },
+        "TikTok": {
+            "domains": [
+                "tiktok.com"
+            ]
+        },
         "Tuenti": {
             "domains": [
                 "tuenti.com"
@@ -4133,9 +4137,19 @@
         }
     },
     "unknown": {
+        "Afterpay": {
+            "domains": [
+                "afterpay.com"
+            ]
+        },
         "Criteo": {
             "domains": [
                 "criteo.com"
+            ]
+        },
+        "Gleam": {
+            "domains": [
+                "gleam.io"
             ]
         },
         "GMA Deals": {

--- a/pyreferrer/data/referrers.json
+++ b/pyreferrer/data/referrers.json
@@ -3988,7 +3988,7 @@
                 "renren.com"
             ]
         },
-        "Share A Sale": {
+        "ShareASale": {
             "domains": [
                 "shareasale.com",
                 "shareasale-analytics.com"
@@ -4184,7 +4184,7 @@
                 "linkin.bio"
             ]
         },
-        "Linktr.ee": {
+        "Linktree": {
             "domains": [
                 "linktr.ee"
             ]
@@ -4194,7 +4194,7 @@
                 "outbrain.com"
             ]
         },
-        "Porn Hub": {
+        "PornHub": {
             "domains": [
                 "pornhub.com"
             ]

--- a/pyreferrer/referrer_test.py
+++ b/pyreferrer/referrer_test.py
@@ -488,6 +488,75 @@ def test_pyreferrer_works_with_unicode_query_terms():
         'subdomain': 'buy.theanimalrescuesite',
         'tld': 'com',
         'type': 'indirect',
-        'url': 'https://buy.theanimalrescuesite.greatergood.com/products/74275-pet-lovers-ultralite-woven-mary-jane-shoes?utm_source=ARS-ARS-LAL&utm_medium=paid-fb&utm_term=02052017&utm_content=Photo&utm_campaign=PetLoversUltralite™WovenMaryJaneShoes_74275&origin=ARS_face_sponsor_ARS-LAL_PetLoversUltralite™WovenMaryJaneShoes_74275_02052017' 
+        'url': 'https://buy.theanimalrescuesite.greatergood.com/products/74275-pet-lovers-ultralite-woven-mary-jane-shoes?utm_source=ARS-ARS-LAL&utm_medium=paid-fb&utm_term=02052017&utm_content=Photo&utm_campaign=PetLoversUltralite™WovenMaryJaneShoes_74275&origin=ARS_face_sponsor_ARS-LAL_PetLoversUltralite™WovenMaryJaneShoes_74275_02052017'
     }
     assert_equals(referrer, expected_referrer)
+
+def test_maps_same_label_with_different_suffix():
+    pinterest_com = Referrer.parse('https://pinterest.com')
+    pinterest_uk = Referrer.parse('https://pinterest.co.uk')
+    pinterest_au = Referrer.parse('https://www.pinterest.com.au')
+    pinterest_ca = Referrer.parse('https://pinterest.ca')
+    pinterest_non_registered_domain = Referrer.parse('https://pinterest.bs')
+
+    expected_com = {
+        'type': Referrer.Types.SOCIAL,
+        'label': 'Pinterest',
+        'url': 'https://pinterest.com',
+        'domain': 'pinterest',
+        'subdomain': '',
+        'tld': 'com',
+        'path': '',
+        'query': ''
+    }
+
+    expected_uk = {
+        'type': Referrer.Types.SOCIAL,
+        'label': 'Pinterest',
+        'url': 'https://pinterest.co.uk',
+        'domain': 'pinterest',
+        'subdomain': '',
+        'tld': 'co.uk',
+        'path': '',
+        'query': ''
+    }
+
+    expected_au = {
+        'type': Referrer.Types.SOCIAL,
+        'label': 'Pinterest',
+        'url': 'https://www.pinterest.com.au',
+        'domain': 'pinterest',
+        'subdomain': 'www',
+        'tld': 'com.au',
+        'path': '',
+        'query': ''
+    }
+
+    expected_ca = {
+        'type': Referrer.Types.SOCIAL,
+        'label': 'Pinterest',
+        'url': 'https://pinterest.ca',
+        'domain': 'pinterest',
+        'subdomain': '',
+        'tld': 'ca',
+        'path': '',
+        'query': ''
+    }
+
+    # .bs is not a registered domain for Pinterest so it should map to INDIRECT
+    expected_bs = {
+        'type': Referrer.Types.INDIRECT,
+        'label': 'Pinterest',
+        'url': 'https://pinterest.bs',
+        'domain': 'pinterest',
+        'subdomain': '',
+        'tld': 'bs',
+        'path': '',
+        'query': ''
+    }
+
+    assert_equals(pinterest_com, expected_com)
+    assert_equals(pinterest_uk, expected_uk)
+    assert_equals(pinterest_au, expected_au)
+    assert_equals(pinterest_ca, expected_ca)
+    assert_equals(pinterest_non_registered_domain, expected_bs)

--- a/pyreferrer/referrer_test.py
+++ b/pyreferrer/referrer_test.py
@@ -492,7 +492,7 @@ def test_pyreferrer_works_with_unicode_query_terms():
     }
     assert_equals(referrer, expected_referrer)
 
-def test_maps_same_label_with_different_suffix():
+def test_different_domain_suffix_maps_to_known_label():
     pinterest_com = Referrer.parse('https://pinterest.com')
     pinterest_uk = Referrer.parse('https://pinterest.co.uk')
     pinterest_au = Referrer.parse('https://www.pinterest.com.au')


### PR DESCRIPTION
This PR extends the referrer.json file to include some more recent common traffic referrals.

Referrers can fall into one of four types. In this PR I updated:
`search` to include Google domains for ad services, Yelp and MSN.

`social` to include more Pinterest domains with different suffix, TikTok and Share A Sale which is a platform for Affiliate Marketing which is mostly having Affiliates share products across social channels.

`unknown` to include many domains that are sometimes paid services used for boosting traffic to a site or sites that list products and deals which contribute to a lot of traffic.

In this notebook I have a list of each of the new domains by type and I pass them through both the current version of pyreferrer and the updated version to see if they map to the appropriate type: https://notebooks.shopifycloud.com/user/racheal.herlihy/notebooks/racheal.herlihy/Pyreferrer%20Top%20Hat.ipynb
