### PR TITLE
Set up a development environment

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,15 @@
+name: pyreferrer
+
+up:
+  - python: 2.7.15
+  - python: 3.5.7
+  - pip:
+    - requirements.txt
+  - python_develop
+
+commands:
+  clean:
+    run: find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+
+  test:
+    run: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 tldextract==2.0.2
 six==1.10.0
+nose==1.3.7
+tox==2.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27, py35
+
+[testenv]
+commands = nosetests
+deps =
+    -rrequirements.txt


### PR DESCRIPTION
I activated Travis CI (for real).

CI fails for Python 3 because encode and decode are not defined on strings. I'll fix that in a following PR.

This PR sets up a proper development environment.

