### PR TITLE
Allow a range of versions for `tldextract`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tldextract==2.0.2
+tldextract>=2.0.2,<=2.2.1
 six==1.11.0
 nose==1.3.7
 pyreleaser==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     license="MIT",
     packages=["pyreferrer"],
     package_data={"pyreferrer": ["data/*"]},
-    install_requires=["tldextract==2.0.2", "six==1.11.0"],
+    install_requires=["tldextract>=2.0.2,<=2.2.1", "six==1.11.0"],
     extras_require={"test": ["nose"]},
     classifiers=[
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
We have been successfully using a [custom version](https://github.com/prabcs/tldextract) of `tldextract` along with `pyreferrer==0.5.0` for some time now. Expanding the range of versions in `setup.py` would enable us to also resolve some dependency conflicts we have.