### PR TITLE
Bump Python and six versions

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,8 +1,8 @@
 name: pyreferrer
 
 up:
-  - python: 2.7.15
-  - python: 3.6.2
+  - python: 2.7.17
+  - python: 3.7.9
   - pip:
     - requirements.txt
   - python_develop

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tldextract>=2.0.2,<=2.2.1
-six==1.11.0
+six>=1.11.0
 nose==1.3.7
 pyreleaser==0.5.2
 tox==2.7.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '0.6.5'  # maintained by release tool
+VERSION = '0.6.6'  # maintained by release tool
 
 
 setup(
@@ -13,7 +13,7 @@ setup(
     license="MIT",
     packages=["pyreferrer"],
     package_data={"pyreferrer": ["data/*"]},
-    install_requires=["tldextract>=2.0.2,<=2.2.1", "six==1.11.0"],
+    install_requires=["tldextract>=2.0.2,<=2.2.1", "six>=1.11.0"],
     extras_require={"test": ["nose"]},
     classifiers=[
         "License :: OSI Approved :: MIT License",
@@ -24,6 +24,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+	"Programming Language :: Python :: 3.7"
     ],
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = '0.6.6'  # maintained by release tool
+VERSION = '0.6.5'  # maintained by release tool
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py37
 
 [testenv]
 commands = nosetests


### PR DESCRIPTION
Add support for Python 3.7 and allow versions of `six` >= 1.11.0.